### PR TITLE
Spelling fixes for Zork II

### DIFF
--- a/gverbs.zil
+++ b/gverbs.zil
@@ -1268,7 +1268,7 @@ you kill yourself, just as he might have done!" CR>
 					     '<FSET? ,HERE ,NONLANDBIT>)
 					    (ELSE
 					     '<NOT <FSET? ,HERE ,RLANDBIT>>)>
-		                     <TELL "out and disappears">)
+		                     <TELL "out and disappear">)
 	                            (T
 		                     <TELL "to the ground">)>
 	                      <TELL "." CR>)


### PR DESCRIPTION
These are the spelling fixes for Zork II from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.