### PR TITLE
Warning fixes

### DIFF
--- a/actions.zil
+++ b/actions.zil
@@ -2196,7 +2196,7 @@ D .V " instead." CR>
 	       (<VERB? EXAMINE LOOK-INSIDE>
 		<DWINDOW-DESC>)>>
 
-<ROUTINE DIAMOND-MOTION (RARG "AUX" DC DIR RM)
+<ROUTINE DIAMOND-MOTION (RARG "AUX" DIR RM)
 	 <COND (<EQUAL? .RARG ,M-LOOK>
 		<TELL
 "This is a room with oddly angled walls and passages in all directions.
@@ -3169,7 +3169,7 @@ wall, and contents himself with splashing you with water." CR>)
 		<TELL
 "This may only be a baby sea serpent, but it's as big as a small whale." CR>)>>
 
-<ROUTINE GENIE-FCN ("OPTIONAL" (RARG ,M-OBJECT) "AUX" V HOARD)
+<ROUTINE GENIE-FCN ("OPTIONAL" (RARG ,M-OBJECT) "AUX" HOARD)
 	<COND (<VERB? HELLO>
 	       <TELL
 "The genie grins demonically, but says nothing." CR>)
@@ -3987,7 +3987,7 @@ up completely, but you can't have everything." CR CR>
 		 <KILL-INTERRUPTS>
 		 <RFATAL>>>
 
-<ROUTINE RANDOMIZE-OBJECTS ("AUX" (R <>) F N L)
+<ROUTINE RANDOMIZE-OBJECTS ("AUX" (R <>) F N)
 	 <COND (<IN? ,LAMP ,WINNER>
 		<MOVE ,LAMP ,INSIDE-BARROW>)>
 	 <SET N <FIRST? ,WINNER>>


### PR DESCRIPTION
This fixes most - not all - of the warnings produced by ZILF 0.9. I think this is a good idea, because otherwise warnings and errors tend to get lost in the noise.

The remaining warnings are:

```
[warning ZIL0210] ../zork-substrate/parser.zil:1040: local variable 'BITS' is never used
[warning ZIL0210] ../zork-substrate/verbs.zil:526: local variable 'LST' is never used
[warning ZIL0210] ../zork-substrate/verbs.zil:526: local variable 'MAX' is never used
[warning ZIL0210] ../zork-substrate/verbs.zil:526: local variable 'CNT' is never used
[warning ZIL0210] ../zork-substrate/verbs.zil:996: local variable 'LOCN' is never used
```

I haven't included the warnings fixed by https://github.com/the-infocom-files/zork-substrate/pull/6