### PR TITLE
Fixed or mitigated various balloon glitches (don't necessarily merge)

### DIFF
--- a/actions.zil
+++ b/actions.zil
@@ -320,7 +320,8 @@ jagged cliffs of the Flathead Mountains!">)
 		  (T <PUT-BALLOON .R "descends.">)>)>>
 
 <ROUTINE BCONTENTS ()
-	 <COND (<VERB? TAKE>
+	 <COND (<AND <VERB? TAKE>
+		     <EQUAL? ,PRSO ,CLOTH-BAG ,RECEPTACLE ,BRAIDED-WIRE>>
 		<TELL
 "The " D ,PRSO " is an integral part of the basket and cannot
 be removed.">

--- a/actions.zil
+++ b/actions.zil
@@ -190,11 +190,6 @@ receptacle is fastened to the center of the basket">)>
 			      <TELL
 "You can't control the balloon this way." CR>
 			      <RTRUE>)>)
-		      (<AND <VERB? TAKE>
-			    <EQUAL? ,BINF-FLAG ,PRSO>>
-		       <TELL "You don't really want to hold a burning "
-			     D ,PRSO "." CR>
-		       <RTRUE>)
 		      (<VERB? INFLATE>
 		       <TELL
 "It takes more than words to inflate a balloon." CR>)>)>>
@@ -353,6 +348,11 @@ within the basket but cannot be removed." CR>)>>
 		<RTRUE>)
 	       (T
 		<BCONTENTS>)>>
+
+<ROUTINE RECEPTACLE-CONT ()
+	 <COND (<EQUAL? ,BINF-FLAG ,PRSO>
+		<TELL "You don't really want to hold a burning "
+		      D ,PRSO "." CR>)>>
 
 <ROUTINE WIRE-FCN ()
         <COND (<VERB? TAKE FIND EXAMINE>

--- a/actions.zil
+++ b/actions.zil
@@ -203,15 +203,6 @@ receptacle is fastened to the center of the basket">)>
 		       <TELL "You don't really want to hold a burning "
 			     D ,PRSO "." CR>
 		       <RTRUE>)
-		      (<AND <VERB? PUT>
-			    <EQUAL? ,PRSI ,RECEPTACLE>
-			    <FIRST? ,RECEPTACLE>>
-		       <TELL "The receptacle is already occupied." CR>
-		       <RTRUE>)
-		      (<AND <VERB? PUT>
-			    <EQUAL? ,PRSI ,RECEPTACLE>>
-		       <FSET ,PRSO ,NDESCBIT>
-		       <RFALSE>)
 		      (<VERB? INFLATE>
 		       <TELL
 "It takes more than words to inflate a balloon." CR>)>)>>
@@ -352,6 +343,16 @@ be removed.">
 	        <TELL
 "The " D ,PRSO " is part of the basket. It may be manipulated
 within the basket but cannot be removed." CR>)>>
+
+<ROUTINE RECEPTACLE-FCN ()
+	 <COND (<AND <VERB? PUT>
+		     <FIRST? ,RECEPTACLE>>
+		<TELL "The receptacle is already occupied." CR>)
+	       (<VERB? PUT>
+		<FSET ,PRSO ,NDESCBIT>
+		<RFALSE>)
+	       (T
+		<BCONTENTS>)>>
 
 <ROUTINE WIRE-FCN ()
         <COND (<VERB? TAKE FIND EXAMINE>

--- a/actions.zil
+++ b/actions.zil
@@ -331,7 +331,7 @@ be removed.">
 "The " D ,PRSO " is part of the basket. It may be manipulated
 within the basket but cannot be removed." CR>)>>
 
-<ROUTINE RECEPTACLE-FCN ()
+<ROUTINE RECEPTACLE-FCN ("AUX" RC)
 	 <COND (<AND <VERB? PUT>
 		     <FIRST? ,RECEPTACLE>>
 		<TELL "The receptacle is already occupied." CR>)
@@ -345,6 +345,15 @@ within the basket but cannot be removed." CR>)>>
 		      D ,BINF-FLAG "." CR>
 		<FSET ,RECEPTACLE ,OPENBIT>
 		<RTRUE>)
+	       (<AND <VERB? LOOK-INSIDE>
+		     <FSET? ,RECEPTACLE ,OPENBIT>
+		     <SET RC <FIRST? ,RECEPTACLE>>>
+		<TELL "A " D .RC " is "
+		      <COND (<EQUAL? ,BINF-FLAG .RC>
+			     "burning")
+			    (T
+			     "nestled")>
+		      " inside." CR>)
 	       (T
 		<BCONTENTS>)>>
 

--- a/actions.zil
+++ b/actions.zil
@@ -207,8 +207,7 @@ receptacle is fastened to the center of the basket">)>
 	<ENABLE <QUEUE I-BURNUP <* <GETP ,PRSO ,P?SIZE> 20>>>
 	<FSET ,PRSO ,FLAMEBIT>
 	<FSET ,PRSO ,ONBIT>
-	<FCLEAR ,PRSO ,TAKEBIT>
-	<FCLEAR ,PRSO ,READBIT>
+	<FSET ,PRSO ,TRYTAKEBIT>
 	<COND (,BINF-FLAG <RTRUE>)
 	      (T
 	       <TELL

--- a/actions.zil
+++ b/actions.zil
@@ -190,14 +190,6 @@ receptacle is fastened to the center of the basket">)>
 			      <TELL
 "You can't control the balloon this way." CR>
 			      <RTRUE>)>)
-		      (<AND <VERB? OPEN>
-			    ,BINF-FLAG
-			    <EQUAL? ,PRSO ,RECEPTACLE>
-			    <FIRST? ,RECEPTACLE>>
-		       <TELL "Opening it reveals a burning "
-			     D ,BINF-FLAG "." CR>
-		       <FSET ,RECEPTACLE ,OPENBIT>
-		       <RTRUE>)
 		      (<AND <VERB? TAKE>
 			    <EQUAL? ,BINF-FLAG ,PRSO>>
 		       <TELL "You don't really want to hold a burning "
@@ -352,6 +344,13 @@ within the basket but cannot be removed." CR>)>>
 	       (<VERB? PUT>
 		<FSET ,PRSO ,NDESCBIT>
 		<RFALSE>)
+	       (<AND <VERB? OPEN>
+		     ,BINF-FLAG
+		     <FIRST? ,RECEPTACLE>>
+		<TELL "Opening it reveals a burning "
+		      D ,BINF-FLAG "." CR>
+		<FSET ,RECEPTACLE ,OPENBIT>
+		<RTRUE>)
 	       (T
 		<BCONTENTS>)>>
 

--- a/dungeon.zil
+++ b/dungeon.zil
@@ -2191,7 +2191,7 @@ the like of which is rarely seen outside the Great Underground Empire.")>
 	(ADJECTIVE METAL)
 	(DESC "receptacle")
 	(FLAGS CONTBIT SEARCHBIT NDESCBIT)
-	(ACTION BCONTENTS)
+	(ACTION RECEPTACLE-FCN)
 	(CAPACITY 6)>
 
 <OBJECT ROBOT

--- a/dungeon.zil
+++ b/dungeon.zil
@@ -2192,6 +2192,7 @@ the like of which is rarely seen outside the Great Underground Empire.")>
 	(DESC "receptacle")
 	(FLAGS CONTBIT SEARCHBIT NDESCBIT)
 	(ACTION RECEPTACLE-FCN)
+	(CONTFCN RECEPTACLE-CONT)
 	(CAPACITY 6)>
 
 <OBJECT ROBOT


### PR DESCRIPTION
This is just my attempt at fixing or mitigating various balloon glitches.

- Putting objects in the receptacle should work the same, regardless of whether or not you are inside the balloon.
- Taking objects from the receptacle should work the same, regardless of whether or not you are inside the balloon.
- "TAKE _object_ FROM RECEPTACLE" should work as expected now. Before the game would claim that the object was an integral part of the balloon.
- Opening the receptacle should print the same message, regardless of whether or not you are inside the balloon.
- Use ```CNTFCN``` to prevent taking burning objects from the receptacle. It seems like the more elegant solution, if you ask me, and it means that it doesn't make any difference whether or not you are inside the balloon.
- "LOOK IN RECEPTACLE"  no longer says it's empty when there's something inside.

Known issues:

- Using ```CNTFCN``` doesn't prevent implicit taking (e.g. "READ NEWSPAPER"). I don't think it can be handled by any action routine, so to get around it any object burned inside the receptacle automatically gets ```TRYTAKEBIT```. No attempt is made at clearing the bit afterwards. (Doing so would probably require changing code that's currently in ```V-POUR-ON``` in zork-substrate.) Still, it seems better than the old way, which was to remove ```TAKEBIT``` and ```READBIT``` from the object.
- Since the game no longer removes ```TAKEBIT``` from objects burning in the receptacle, I've probably opened up for frying them with the wizard's wand, thus removing them. Oops! And we can probably filch them, too. Double oops!
