### PR TITLE
Fix for the sea serpent and the crystal sphere not being described as was probably intended

### DIFF
--- a/actions.zil
+++ b/actions.zil
@@ -1686,10 +1686,7 @@ dust rises from beneath it." CR>
 	       (<VERB? EXAMINE>
 		<TELL
 "There is something misty in the sphere. Perhaps if you were to look
-into it..." CR>)
-	       (<AND <VERB? TAKE> <==? ,PRSO ,PALANTIR-3>>
-		<PUTP ,PRSO ,P?LDESC <>>
-		<RFALSE>)>>
+into it..." CR>)>>
 
 <ROUTINE DEAD-PALANTIR (RARG "AUX" P)
 	 <COND (<EQUAL? .RARG ,M-LOOK>

--- a/dungeon.zil
+++ b/dungeon.zil
@@ -1209,7 +1209,7 @@ the east is fitful light.")
 	(SYNONYM PALANTIR SPHERE)
 	(ADJECTIVE CRYSTAL WHITE CLEAR)
 	(DESC "clear crystal sphere")
-	(LDESC "There is a clear crystal sphere lying in the sand.")
+	(FDESC "There is a clear crystal sphere lying in the sand.")
 	(FLAGS STAGGERED TAKEBIT NDESCBIT TRANSBIT)
 	(ACTION PALANTIR)
 	(VALUE 20)>
@@ -1219,7 +1219,7 @@ the east is fitful light.")
 	(SYNONYM SERPENT SNAKE)
 	(ADJECTIVE BABY SEA)
 	(DESC "baby sea serpent")
-	(LDESC "There is a baby sea serpent swimming in the aquarium.")
+	(FDESC "There is a baby sea serpent swimming in the aquarium.")
 	(FLAGS ACTORBIT)
 	(ACTION SERPENT-FCN)>
 


### PR DESCRIPTION
This is in response to my initially somewhat confused bug report https://github.com/the-infocom-files/zork2/issues/56

Here is what the game currently looks like:

```
>LOOK
Aquarium Room
Here a dark hallway turns a corner. To the south is a dark room, to the east is
fitful light.
Filling the northern half of the room is a huge aquarium.
The aquarium contains:
  A baby sea serpent

>THROW SWORD AT AQUARIUM
[snipped for brevity]

>LOOK
Aquarium Room
Here a dark hallway turns a corner. To the south is a dark room, to the east is
fitful light.
A sword of Elvish workmanship is on the ground.
There is a dead sea serpent in a heap here.
A shattered aquarium fills the northern half of the room.
The aquarium contains:
  A clear crystal sphere
```

Both the sea serpent and the sphere have an ```LDESC```, but that's never printed because they're inside a container. The sphere's ```LDESC``` gets cleared when you pick it up, so it's made to act like an ```FDESC```.

Simply changing the ```LDESC``` to ```FDESC``` makes it look like the author probably intended:

```
>LOOK
Aquarium Room
Here a dark hallway turns a corner. To the south is a dark room, to the east is
fitful light.
Filling the northern half of the room is a huge aquarium.
There is a baby sea serpent swimming in the aquarium.

>THROW SWORD AT AQUARIUM
[snipped for brevity]

>LOOK
Aquarium Room
Here a dark hallway turns a corner. To the south is a dark room, to the east is
fitful light.
A sword of Elvish workmanship is on the ground.
There is a dead sea serpent in a heap here.
A shattered aquarium fills the northern half of the room.
There is a clear crystal sphere lying in the sand.
```